### PR TITLE
fix mineru asset cropping

### DIFF
--- a/app/editable_ppt/browser.py
+++ b/app/editable_ppt/browser.py
@@ -100,6 +100,21 @@ def _read_runtime_state(page) -> dict[str, object]:
     )
 
 
+def _summarize_browser_errors(page_errors: list[str], console_errors: list[str]) -> str:
+    seen: set[str] = set()
+    merged: list[str] = []
+    for source, rows in (("pageerror", page_errors), ("console", console_errors)):
+        for row in rows:
+            message = str(row or "").strip()
+            if not message or message in seen:
+                continue
+            seen.add(message)
+            merged.append(f"{source}: {message}")
+            if len(merged) >= 3:
+                return " | ".join(merged)
+    return " | ".join(merged)
+
+
 def execute_html_and_download_pptx_with_runtime(
     html_path: Path,
     download_dir: Path,
@@ -117,6 +132,8 @@ def execute_html_and_download_pptx_with_runtime(
     save_path: Path | None = None
     run_error: Exception | None = None
     runtime_state: dict[str, object] = {"matches": {}, "used_ids": {}}
+    page_errors: list[str] = []
+    console_errors: list[str] = []
 
     try:
         playwright = sync_playwright().start()
@@ -126,13 +143,22 @@ def execute_html_and_download_pptx_with_runtime(
         browser = playwright.chromium.launch(**launch_kwargs)
         context = browser.new_context(accept_downloads=True)
         page = context.new_page()
+        page.on("pageerror", lambda exc: page_errors.append(str(exc)))
+        page.on(
+            "console",
+            lambda msg: console_errors.append(msg.text)
+            if msg.type == "error"
+            else None,
+        )
 
         page.goto(html_path.resolve().as_uri(), wait_until="domcontentloaded", timeout=90000)
         wait_for_pptxgenjs(page, timeout_ms=60000)
 
         has_generate_fn = page.evaluate("() => typeof window.generateSlide === 'function'")
         if not has_generate_fn:
-            raise RuntimeError("Generated HTML does not define function generateSlide().")
+            error_summary = _summarize_browser_errors(page_errors, console_errors)
+            detail = f" JavaScript runtime errors: {error_summary}" if error_summary else ""
+            raise RuntimeError(f"Generated HTML does not define function generateSlide().{detail}")
 
         try:
             with page.expect_download(timeout=timeout_ms) as download_info:
@@ -140,10 +166,14 @@ def execute_html_and_download_pptx_with_runtime(
             download = download_info.value
             runtime_state = _read_runtime_state(page)
         except PlaywrightTimeoutError as exc:
-            run_error = TimeoutError("No PPTX download event was detected after generateSlide().")
+            error_summary = _summarize_browser_errors(page_errors, console_errors)
+            detail = f" JavaScript runtime errors: {error_summary}" if error_summary else ""
+            run_error = TimeoutError(f"No PPTX download event was detected after generateSlide().{detail}")
             run_error.__cause__ = exc
         except Exception as exc:  # noqa: BLE001
-            run_error = RuntimeError(f"generateSlide() execution failed: {exc}")
+            error_summary = _summarize_browser_errors(page_errors, console_errors)
+            detail = f" JavaScript runtime errors: {error_summary}" if error_summary else ""
+            run_error = RuntimeError(f"generateSlide() execution failed: {exc}{detail}")
 
         if run_error is None:
             suggested_name = download.suggested_filename or "editable_deck.pptx"

--- a/app/editable_ppt/codegen.py
+++ b/app/editable_ppt/codegen.py
@@ -11,6 +11,12 @@ from app.model_api import chat_completion_text
 PROMPT_PATH = Path(__file__).resolve().parent.parent / "prompts" / "editable_slide_builder.md"
 
 
+class SlideCodegenError(ValueError):
+    def __init__(self, message: str, *, raw_text: str = "") -> None:
+        super().__init__(message)
+        self.raw_text = raw_text
+
+
 def load_prompt_text(prompt_file: Optional[Path]) -> str:
     path = prompt_file or PROMPT_PATH
     if not path.exists():
@@ -165,6 +171,10 @@ def _extract_function(text: str, name: str) -> Optional[str]:
     return text[match.start() : close_brace + 1].strip()
 
 
+def _has_function_marker(text: str, name: str) -> bool:
+    return bool(re.search(rf"(async\s+)?function\s+{name}\s*\(", text))
+
+
 def _extract_script_content(text: str) -> Optional[str]:
     matches = re.findall(r"<script[^>]*>(.*?)</script>", text, flags=re.IGNORECASE | re.DOTALL)
     if matches:
@@ -281,10 +291,16 @@ def normalize_slide_builder(raw_text: str) -> str:
         build_slide = _extract_function(candidate, "buildSlide")
         if build_slide:
             return _sanitize_builder_code(_remove_function_definition(build_slide, "addPH").strip())
+        if _has_function_marker(candidate, "buildSlide"):
+            raise ValueError("Model output contained a buildSlide() declaration, but the function body was incomplete or truncated.")
 
         generate_slide = _extract_function(candidate, "generateSlide")
         if generate_slide:
             return _sanitize_builder_code(_normalize_generate_slide(generate_slide))
+        if _has_function_marker(candidate, "generateSlide"):
+            raise ValueError(
+                "Model output contained a generateSlide() declaration, but the function body was incomplete or truncated."
+            )
 
         if "slide.add" in candidate or "addPH(" in candidate:
             return _wrap_inline_slide_code(candidate)
@@ -341,5 +357,9 @@ def call_model_for_slide_code(
         temperature=None,
         max_tokens=max_tokens,
     )
-    builder = normalize_slide_builder(normalize_content(raw_text))
+    normalized_text = normalize_content(raw_text)
+    try:
+        builder = normalize_slide_builder(normalized_text)
+    except ValueError as exc:
+        raise SlideCodegenError(str(exc), raw_text=normalized_text) from exc
     return raw_text, builder

--- a/app/editable_ppt/mineru_assets.py
+++ b/app/editable_ppt/mineru_assets.py
@@ -22,6 +22,32 @@ MINERU_UPLOAD_SCALE_STEPS = (1.0, 0.9, 0.8, 0.72, 0.64, 0.56, 0.48, 0.4, 0.33, 0
 MINERU_UPLOAD_JPEG_QUALITIES = (90, 84, 78, 72, 66, 60)
 VISUAL_ELEMENT_TYPES = {"image", "table", "equation"}
 UNMATCHED_PH_REGION_EXPAND_RATIO = 1.5
+MATCH_MIN_ASPECT_SCORE = 0.25
+MATCH_MIN_AREA_SCORE = 0.18
+MATCH_MIN_IOU = 0.12
+MATCH_MIN_PLACEHOLDER_COVER = 0.45
+MATCH_MAX_ELEMENT_TO_PLACEHOLDER_RATIO = 8.5
+MATCH_OVERSIZED_RATIO = 1.75
+MATCH_OVERSIZED_RATIO_HARD = 2.25
+MATCH_LOW_ELEMENT_COVER = 0.58
+MATCH_LOW_IOU_FOR_OVERSIZED = 0.4
+PLACEHOLDER_CUTOUT_EXPAND_RATIO = 0.12
+PLACEHOLDER_CUTOUT_FALLBACK_EXPAND_RATIO = 0.2
+PLACEHOLDER_CUTOUT_INSET_X_RATIO = 0.04
+PLACEHOLDER_CUTOUT_INSET_TOP_RATIO = 0.01
+PLACEHOLDER_CUTOUT_INSET_BOTTOM_RATIO = 0.05
+SCREENSHOT_CUTOUT_INSET_X_RATIO = 0.08
+SCREENSHOT_CUTOUT_INSET_TOP_RATIO = 0.015
+SCREENSHOT_CUTOUT_INSET_BOTTOM_RATIO = 0.09
+SCREENSHOT_SUBJECT_SAFE_X_RATIO = 0.03
+SCREENSHOT_SUBJECT_SAFE_TOP_RATIO = 0.01
+SCREENSHOT_SUBJECT_SAFE_BOTTOM_RATIO = 0.08
+SCREENSHOT_SUBJECT_PAD_X_RATIO = 0.035
+SCREENSHOT_SUBJECT_PAD_TOP_RATIO = 0.025
+SCREENSHOT_SUBJECT_PAD_BOTTOM_RATIO = 0.03
+GRAPHIC_CUTOUT_BLEED_RATIO = 0.05
+SALVAGE_MIN_PLACEHOLDER_COVER = 0.82
+SALVAGE_MAX_CENTER_DISTANCE = 0.08
 
 
 @dataclass(frozen=True)
@@ -206,6 +232,16 @@ def _intersection_area(a: list[int], b: list[int]) -> int:
     return max(0, x2 - x1) * max(0, y2 - y1)
 
 
+def _intersect_bbox(a: list[int], b: list[int]) -> Optional[list[int]]:
+    x1 = max(a[0], b[0])
+    y1 = max(a[1], b[1])
+    x2 = min(a[2], b[2])
+    y2 = min(a[3], b[3])
+    if x2 <= x1 or y2 <= y1:
+        return None
+    return [x1, y1, x2, y2]
+
+
 def _iou(a: list[int], b: list[int]) -> float:
     inter = _intersection_area(a, b)
     if inter <= 0:
@@ -322,6 +358,32 @@ def _area_score(a: list[int], b: list[int]) -> float:
     return max(0.0, 1.0 - min(abs(ratio) / 3.0, 1.0))
 
 
+def _match_score(
+    *,
+    center_norm: float,
+    iou: float,
+    ph_cover: float,
+    element_cover: float,
+    aspect_score: float,
+    area_score: float,
+    element_to_placeholder_ratio: float,
+) -> float:
+    center_score = 1.0 / (1.0 + center_norm)
+    oversized_penalty = 0.0
+    if element_to_placeholder_ratio > MATCH_OVERSIZED_RATIO:
+        oversized_penalty = min((element_to_placeholder_ratio - MATCH_OVERSIZED_RATIO) / 3.0, 0.35)
+    score = (
+        center_score * 0.35
+        + iou * 0.2
+        + ph_cover * 0.16
+        + element_cover * 0.14
+        + aspect_score * 0.08
+        + area_score * 0.07
+        - oversized_penalty
+    )
+    return max(0.0, min(score, 1.0))
+
+
 def _prompt_for_element(element: dict[str, Any], image_area: int) -> str:
     bbox = element["bbox"]
     area_ratio = _rect_area(bbox) / max(image_area, 1)
@@ -376,7 +438,16 @@ def _match_metrics(
     center_norm = _center_distance_norm(ph_bbox, element_bbox, image_diagonal)
     aspect_score = _aspect_score(ph_bbox, element_bbox)
     area_score = _area_score(ph_bbox, element_bbox)
-    score = 1.0 / (1.0 + center_norm)
+    element_to_placeholder_ratio = element_area / max(ph_area, 1)
+    score = _match_score(
+        center_norm=center_norm,
+        iou=iou,
+        ph_cover=ph_cover,
+        element_cover=element_cover,
+        aspect_score=aspect_score,
+        area_score=area_score,
+        element_to_placeholder_ratio=element_to_placeholder_ratio,
+    )
     return {
         "placeholder_id": placeholder["placeholder_id"],
         "element_id": element["element_id"],
@@ -388,20 +459,46 @@ def _match_metrics(
         "placeholder_area": ph_area,
         "element_area": element_area,
         "placeholder_to_element_ratio": round(ph_area / max(element_area, 1), 6),
-        "element_to_placeholder_ratio": round(element_area / max(ph_area, 1), 6),
+        "element_to_placeholder_ratio": round(element_to_placeholder_ratio, 6),
         "aspect_score": round(aspect_score, 6),
         "area_score": round(area_score, 6),
     }
 
 
+def _is_oversized_match(metrics: dict[str, Any]) -> bool:
+    element_ratio = float(metrics["element_to_placeholder_ratio"])
+    iou = float(metrics["iou"])
+    element_cover = float(metrics["element_cover"])
+    return (
+        element_ratio >= MATCH_OVERSIZED_RATIO_HARD
+        or (element_ratio >= MATCH_OVERSIZED_RATIO and iou < MATCH_LOW_IOU_FOR_OVERSIZED)
+        or (element_ratio >= 1.45 and element_cover < MATCH_LOW_ELEMENT_COVER)
+    )
+
+
+def _can_salvage_oversized_match(metrics: dict[str, Any]) -> bool:
+    if not _is_oversized_match(metrics):
+        return True
+    return (
+        float(metrics["ph_cover"]) >= SALVAGE_MIN_PLACEHOLDER_COVER
+        and float(metrics["center_distance_norm"]) <= SALVAGE_MAX_CENTER_DISTANCE
+    )
+
+
 def _is_match_acceptable(metrics: dict[str, Any]) -> bool:
-    if float(metrics["aspect_score"]) < 0.2:
+    if float(metrics["aspect_score"]) < MATCH_MIN_ASPECT_SCORE:
         return False
-    if float(metrics["area_score"]) < 0.12:
+    if float(metrics["area_score"]) < MATCH_MIN_AREA_SCORE:
+        return False
+    if float(metrics["iou"]) < MATCH_MIN_IOU and float(metrics["ph_cover"]) < SALVAGE_MIN_PLACEHOLDER_COVER:
+        return False
+    if float(metrics["ph_cover"]) < MATCH_MIN_PLACEHOLDER_COVER:
         return False
     if float(metrics["placeholder_to_element_ratio"]) > 10.0:
         return False
-    if float(metrics["element_to_placeholder_ratio"]) > 10.0:
+    if float(metrics["element_to_placeholder_ratio"]) > MATCH_MAX_ELEMENT_TO_PLACEHOLDER_RATIO:
+        return False
+    if not _can_salvage_oversized_match(metrics):
         return False
     return True
 
@@ -426,7 +523,11 @@ def _should_refine_candidate(
 ) -> bool:
     if depth >= max_depth:
         return False
-    return _count_related_placeholders(element_bbox, placeholders) > 1
+    if _count_related_placeholders(element_bbox, placeholders) > 1:
+        return True
+    if _is_oversized_match(metrics):
+        return True
+    return float(metrics["iou"]) < 0.32 and float(metrics["ph_cover"]) > 0.72
 
 
 def _load_json_file(path: Path) -> Any:
@@ -704,6 +805,358 @@ def _expand_bbox(
     return [x1, y1, x2, y2]
 
 
+def _inset_bbox(
+    bbox: list[int],
+    *,
+    image_size: tuple[int, int],
+    inset_x_ratio: float,
+    inset_top_ratio: float,
+    inset_bottom_ratio: float,
+) -> list[int]:
+    width, height = image_size
+    bw = max(bbox[2] - bbox[0], 1)
+    bh = max(bbox[3] - bbox[1], 1)
+    x1 = max(0, int(round(bbox[0] + bw * inset_x_ratio)))
+    x2 = min(width, int(round(bbox[2] - bw * inset_x_ratio)))
+    y1 = max(0, int(round(bbox[1] + bh * inset_top_ratio)))
+    y2 = min(height, int(round(bbox[3] - bh * inset_bottom_ratio)))
+    if x2 <= x1:
+        x1, x2 = bbox[0], bbox[2]
+    if y2 <= y1:
+        y1, y2 = bbox[1], bbox[3]
+    return [x1, y1, x2, y2]
+
+
+def _union_bbox(boxes: list[list[int]]) -> Optional[list[int]]:
+    if not boxes:
+        return None
+    x1 = min(box[0] for box in boxes)
+    y1 = min(box[1] for box in boxes)
+    x2 = max(box[2] for box in boxes)
+    y2 = max(box[3] for box in boxes)
+    if x2 <= x1 or y2 <= y1:
+        return None
+    return [x1, y1, x2, y2]
+
+
+def _collect_foreground_components(
+    *,
+    source_rgba: Any,
+    analysis_bbox: list[int],
+    color_threshold: int = 18,
+    max_edge: int = 256,
+) -> list[dict[str, Any]]:
+    Image, _ = _load_pillow()
+    x1, y1, x2, y2 = analysis_bbox
+    crop = source_rgba.crop((x1, y1, x2, y2)).convert("RGB")
+    crop_w, crop_h = crop.size
+    if crop_w <= 1 or crop_h <= 1:
+        return []
+
+    scale = min(1.0, max_edge / max(crop_w, crop_h))
+    if scale < 1.0:
+        small_size = (
+            max(1, int(round(crop_w * scale))),
+            max(1, int(round(crop_h * scale))),
+        )
+        crop = crop.resize(small_size, resample=_lanczos_resample(Image))
+    small_w, small_h = crop.size
+    pixels = crop.load()
+
+    samples: list[tuple[int, int, int]] = []
+    for sx in range(small_w):
+        samples.append(pixels[sx, 0])
+        samples.append(pixels[sx, small_h - 1])
+    for sy in range(1, max(small_h - 1, 1)):
+        samples.append(pixels[0, sy])
+        samples.append(pixels[small_w - 1, sy])
+    if not samples:
+        return []
+    bg = tuple(int(round(sum(channel) / len(samples))) for channel in zip(*samples))
+
+    mask = [False] * (small_w * small_h)
+    for sy in range(small_h):
+        for sx in range(small_w):
+            r, g, b = pixels[sx, sy]
+            diff = abs(r - bg[0]) + abs(g - bg[1]) + abs(b - bg[2])
+            chroma = max(r, g, b) - min(r, g, b)
+            if diff >= color_threshold or chroma >= max(10, color_threshold // 2):
+                mask[sy * small_w + sx] = True
+
+    visited = [False] * len(mask)
+    components: list[dict[str, Any]] = []
+    min_area = max(12, int(small_w * small_h * 0.003))
+    neighbors = ((1, 0), (-1, 0), (0, 1), (0, -1))
+
+    for start_index, is_fg in enumerate(mask):
+        if not is_fg or visited[start_index]:
+            continue
+        stack = [start_index]
+        visited[start_index] = True
+        area = 0
+        min_x = max_x = start_index % small_w
+        min_y = max_y = start_index // small_w
+        while stack:
+            current = stack.pop()
+            cx = current % small_w
+            cy = current // small_w
+            area += 1
+            min_x = min(min_x, cx)
+            max_x = max(max_x, cx)
+            min_y = min(min_y, cy)
+            max_y = max(max_y, cy)
+            for dx, dy in neighbors:
+                nx = cx + dx
+                ny = cy + dy
+                if nx < 0 or ny < 0 or nx >= small_w or ny >= small_h:
+                    continue
+                next_index = ny * small_w + nx
+                if visited[next_index] or not mask[next_index]:
+                    continue
+                visited[next_index] = True
+                stack.append(next_index)
+        if area < min_area:
+            continue
+        scale_x = crop_w / small_w
+        scale_y = crop_h / small_h
+        component_bbox = [
+            x1 + int(round(min_x * scale_x)),
+            y1 + int(round(min_y * scale_y)),
+            x1 + int(round((max_x + 1) * scale_x)),
+            y1 + int(round((max_y + 1) * scale_y)),
+        ]
+        components.append(
+            {
+                "bbox": component_bbox,
+                "area": area,
+                "touches_left": min_x <= 1,
+                "touches_right": max_x >= small_w - 2,
+                "touches_top": min_y <= 1,
+                "touches_bottom": max_y >= small_h - 2,
+            }
+        )
+
+    return components
+
+
+def _component_score(component_bbox: list[int], analysis_bbox: list[int]) -> float:
+    box_area = max(_rect_area(component_bbox), 1)
+    acx = (analysis_bbox[0] + analysis_bbox[2]) / 2.0
+    acy = (analysis_bbox[1] + analysis_bbox[3]) / 2.0
+    bcx = (component_bbox[0] + component_bbox[2]) / 2.0
+    bcy = (component_bbox[1] + component_bbox[3]) / 2.0
+    diagonal = math.hypot(max(analysis_bbox[2] - analysis_bbox[0], 1), max(analysis_bbox[3] - analysis_bbox[1], 1))
+    center_score = 1.0 - min(math.hypot(bcx - acx, bcy - acy) / max(diagonal, 1.0), 1.0)
+    return box_area * (0.55 + center_score)
+
+
+def _expand_bbox_from_base(
+    bbox: list[int],
+    *,
+    base_bbox: list[int],
+    image_size: tuple[int, int],
+    expand_x_ratio: float,
+    expand_top_ratio: float,
+    expand_bottom_ratio: float,
+) -> list[int]:
+    width, height = image_size
+    bw = max(base_bbox[2] - base_bbox[0], 1)
+    bh = max(base_bbox[3] - base_bbox[1], 1)
+    x1 = max(0, int(round(bbox[0] - bw * expand_x_ratio)))
+    x2 = min(width, int(round(bbox[2] + bw * expand_x_ratio)))
+    y1 = max(0, int(round(bbox[1] - bh * expand_top_ratio)))
+    y2 = min(height, int(round(bbox[3] + bh * expand_bottom_ratio)))
+    if x2 <= x1:
+        x1, x2 = bbox[0], bbox[2]
+    if y2 <= y1:
+        y1, y2 = bbox[1], bbox[3]
+    return [x1, y1, x2, y2]
+
+
+def _component_guided_cutout_bbox(
+    *,
+    source_rgba: Any,
+    placeholder_bbox: list[int],
+    element_bbox: list[int],
+    image_size: tuple[int, int],
+    asset_kind: str,
+) -> Optional[list[int]]:
+    analysis_bbox = _intersect_bbox(
+        element_bbox,
+        _expand_bbox(placeholder_bbox, image_size=image_size, extra_ratio=0.18),
+    )
+    if not analysis_bbox or _rect_area(analysis_bbox) <= 16:
+        return None
+
+    components = _collect_foreground_components(
+        source_rgba=source_rgba,
+        analysis_bbox=analysis_bbox,
+        color_threshold=16 if asset_kind == "screenshot" else 14,
+    )
+    if not components:
+        return None
+
+    components.sort(key=lambda item: _component_score(item["bbox"], analysis_bbox), reverse=True)
+
+    if asset_kind == "screenshot":
+        body_candidates = [
+            item
+            for item in components
+            if not item["touches_left"] and not item["touches_right"] and not item["touches_bottom"]
+        ]
+        if not body_candidates:
+            body_candidates = [item for item in components if not item["touches_bottom"]]
+        if not body_candidates:
+            body_candidates = components
+
+        body_candidates.sort(key=lambda item: _component_score(item["bbox"], analysis_bbox), reverse=True)
+        primary = body_candidates[0]["bbox"]
+        safe_box = _inset_bbox(
+            placeholder_bbox,
+            image_size=image_size,
+            inset_x_ratio=SCREENSHOT_SUBJECT_SAFE_X_RATIO,
+            inset_top_ratio=SCREENSHOT_SUBJECT_SAFE_TOP_RATIO,
+            inset_bottom_ratio=SCREENSHOT_SUBJECT_SAFE_BOTTOM_RATIO,
+        )
+        safe_cx = (safe_box[0] + safe_box[2]) / 2.0
+        primary_cx = (primary[0] + primary[2]) / 2.0
+        placeholder_width = max(placeholder_bbox[2] - placeholder_bbox[0], 1)
+        center_bias_cap = placeholder_width * 0.03
+        subject_center_x = safe_cx + max(-center_bias_cap, min(primary_cx - safe_cx, center_bias_cap))
+        left_room = max(subject_center_x - safe_box[0], 1.0)
+        right_room = max(safe_box[2] - subject_center_x, 1.0)
+        primary_half_width = max(primary_cx - primary[0], primary[2] - primary_cx)
+        max_symmetric_half_width = min(left_room, right_room) * 0.96
+        padded_half_width = primary_half_width * (1.0 + SCREENSHOT_SUBJECT_PAD_X_RATIO)
+        final_half_width = min(max_symmetric_half_width, max(primary_half_width, padded_half_width))
+
+        if final_half_width >= primary_half_width:
+            symmetric_bbox = [
+                int(round(subject_center_x - final_half_width)),
+                safe_box[1],
+                int(round(subject_center_x + final_half_width)),
+                safe_box[3],
+            ]
+            clipped = _intersect_bbox(symmetric_bbox, element_bbox)
+            if clipped and _rect_area(clipped) >= max(int(_rect_area(placeholder_bbox) * 0.18), 16):
+                return clipped
+        return None
+
+    selected_boxes: list[list[int]] = []
+    analysis_cx = (analysis_bbox[0] + analysis_bbox[2]) / 2.0
+    analysis_cy = (analysis_bbox[1] + analysis_bbox[3]) / 2.0
+    analysis_diag = math.hypot(max(analysis_bbox[2] - analysis_bbox[0], 1), max(analysis_bbox[3] - analysis_bbox[1], 1))
+    for item in components:
+        box = item["bbox"]
+        bcx = (box[0] + box[2]) / 2.0
+        bcy = (box[1] + box[3]) / 2.0
+        center_dist = math.hypot(bcx - analysis_cx, bcy - analysis_cy) / max(analysis_diag, 1.0)
+        if center_dist > 0.36 and _rect_area(box) < _rect_area(analysis_bbox) * 0.06:
+            continue
+        selected_boxes.append(box)
+        if len(selected_boxes) >= (1 if asset_kind == "screenshot" else 3):
+            break
+
+    union_bbox = _union_bbox(selected_boxes)
+    if not union_bbox:
+        return None
+
+    expanded_union = _expand_bbox_from_base(
+        union_bbox,
+        base_bbox=placeholder_bbox,
+        image_size=image_size,
+        expand_x_ratio=0.03 if asset_kind == "screenshot" else 0.05,
+        expand_top_ratio=0.02,
+        expand_bottom_ratio=0.03 if asset_kind == "screenshot" else 0.05,
+    )
+    clipped_union = _intersect_bbox(expanded_union, analysis_bbox)
+    if clipped_union and _rect_area(clipped_union) >= max(int(_rect_area(placeholder_bbox) * 0.2), 16):
+        return clipped_union
+    return None
+
+
+def _compute_cutout_bbox(
+    *,
+    source_rgba: Any,
+    placeholder_bbox: list[int],
+    element: dict[str, Any],
+    element_bbox: list[int],
+    image_size: tuple[int, int],
+    metrics: dict[str, Any],
+) -> list[int]:
+    if not _is_oversized_match(metrics):
+        return list(element_bbox)
+
+    image_area = image_size[0] * image_size[1]
+    asset_kind = _asset_kind_for_element(element, image_area)
+
+    component_guided = _component_guided_cutout_bbox(
+        source_rgba=source_rgba,
+        placeholder_bbox=placeholder_bbox,
+        element_bbox=element_bbox,
+        image_size=image_size,
+        asset_kind=asset_kind,
+    )
+    if component_guided:
+        return component_guided
+
+    if asset_kind == "screenshot":
+        inset_placeholder_bbox = _inset_bbox(
+            placeholder_bbox,
+            image_size=image_size,
+            inset_x_ratio=SCREENSHOT_CUTOUT_INSET_X_RATIO,
+            inset_top_ratio=SCREENSHOT_CUTOUT_INSET_TOP_RATIO,
+            inset_bottom_ratio=SCREENSHOT_CUTOUT_INSET_BOTTOM_RATIO,
+        )
+        inset_clipped = _intersect_bbox(element_bbox, inset_placeholder_bbox)
+        if inset_clipped and _rect_area(inset_clipped) >= max(int(_rect_area(placeholder_bbox) * 0.24), 16):
+            return inset_clipped
+    else:
+        bleed_placeholder_bbox = _expand_bbox(
+            placeholder_bbox,
+            image_size=image_size,
+            extra_ratio=GRAPHIC_CUTOUT_BLEED_RATIO,
+        )
+        bleed_clipped = _intersect_bbox(element_bbox, bleed_placeholder_bbox)
+        if bleed_clipped and _rect_area(bleed_clipped) >= max(int(_rect_area(placeholder_bbox) * 0.32), 16):
+            return bleed_clipped
+
+        inset_placeholder_bbox = _inset_bbox(
+            placeholder_bbox,
+            image_size=image_size,
+            inset_x_ratio=PLACEHOLDER_CUTOUT_INSET_X_RATIO,
+            inset_top_ratio=PLACEHOLDER_CUTOUT_INSET_TOP_RATIO,
+            inset_bottom_ratio=PLACEHOLDER_CUTOUT_INSET_BOTTOM_RATIO,
+        )
+        inset_clipped = _intersect_bbox(element_bbox, inset_placeholder_bbox)
+        if inset_clipped and _rect_area(inset_clipped) >= max(int(_rect_area(placeholder_bbox) * 0.28), 16):
+            return inset_clipped
+
+    exact_clipped = _intersect_bbox(element_bbox, placeholder_bbox)
+    if exact_clipped and _rect_area(exact_clipped) >= max(int(_rect_area(placeholder_bbox) * 0.35), 16):
+        return exact_clipped
+
+    conservative_bbox = _expand_bbox(
+        placeholder_bbox,
+        image_size=image_size,
+        extra_ratio=min(PLACEHOLDER_CUTOUT_EXPAND_RATIO, 0.04),
+    )
+    clipped = _intersect_bbox(element_bbox, conservative_bbox)
+    if clipped and _rect_area(clipped) >= max(int(_rect_area(placeholder_bbox) * 0.2), 16):
+        return clipped
+
+    fallback_bbox = _expand_bbox(
+        placeholder_bbox,
+        image_size=image_size,
+        extra_ratio=PLACEHOLDER_CUTOUT_FALLBACK_EXPAND_RATIO,
+    )
+    clipped_fallback = _intersect_bbox(element_bbox, fallback_bbox)
+    if clipped_fallback and _rect_area(clipped_fallback) >= 16:
+        return clipped_fallback
+
+    return fallback_bbox
+
+
 def _refine_element_pool(
     *,
     source_image_path: Path,
@@ -950,7 +1403,14 @@ def _render_matches_to_disk(
             placeholder = match["placeholder"]
             element = match["element"]
             metrics = match["metrics"]
-            bbox = element["bbox"]
+            bbox = _compute_cutout_bbox(
+                source_rgba=source_rgba,
+                placeholder_bbox=placeholder["bbox_px"],
+                element=element,
+                element_bbox=element["bbox"],
+                image_size=image_size,
+                metrics=metrics,
+            )
             x1, y1, x2, y2 = bbox
             cutout = source_rgba.crop((x1, y1, x2, y2))
             cutout_name = f"{index:03d}_{placeholder['placeholder_id']}_{element['type']}.png"
@@ -969,6 +1429,7 @@ def _render_matches_to_disk(
                     "prompt": _prompt_for_element(element, image_area),
                     "score": metrics["score"],
                     "bbox": bbox,
+                    "element_bbox": element["bbox"],
                     "placeholder_bbox_px": placeholder["bbox_px"],
                     "placeholder_bbox_slide": placeholder["bbox_slide"],
                     "cutout_path": str(cutout_path),

--- a/app/editable_ppt/service.py
+++ b/app/editable_ppt/service.py
@@ -1,4 +1,4 @@
-﻿from __future__ import annotations
+from __future__ import annotations
 
 import concurrent.futures
 import re
@@ -28,7 +28,7 @@ from .browser import (
     execute_html_and_download_pptx,
     execute_html_and_download_pptx_with_runtime,
 )
-from .codegen import call_model_for_slide_code, load_prompt_text
+from .codegen import SlideCodegenError, call_model_for_slide_code, load_prompt_text
 from .mineru_assets import resolve_mineru_assets_json
 
 ProgressCallback = Optional[Callable[[dict[str, Any]], None]]
@@ -546,6 +546,9 @@ class EditableDeckPipeline:
             )
 
             builder: Optional[str] = None
+            raw_text: str = ""
+            raw_response_path: Optional[Path] = None
+            builder_path = attempt_dir / "build_slide.js"
             try:
                 raw_text, builder = call_model_for_slide_code(
                     provider=runtime_cfg.provider,
@@ -558,8 +561,8 @@ class EditableDeckPipeline:
                     retry_feedback=retry_feedback,
                     previous_builder=previous_builder,
                 )
-                (attempt_dir / "model_response.txt").write_text(raw_text, encoding="utf-8")
-                builder_path = attempt_dir / "build_slide.js"
+                raw_response_path = attempt_dir / "model_response.txt"
+                raw_response_path.write_text(raw_text, encoding="utf-8")
                 builder_path.write_text(builder, encoding="utf-8")
 
                 preview_payload = self._render_preview_artifacts(
@@ -584,20 +587,38 @@ class EditableDeckPipeline:
                 previous_builder = builder
                 best_result = attempt_result
                 break
+            except SlideCodegenError as exc:
+                raw_text = exc.raw_text
+                if raw_text:
+                    raw_response_path = attempt_dir / "model_response.txt"
+                    raw_response_path.write_text(raw_text, encoding="utf-8")
+                last_error = exc
+                retry_feedback = self._build_retry_feedback(exc)
+                (attempt_dir / "error.log").write_text(traceback.format_exc(), encoding="utf-8")
+                result_payload: dict[str, Any] = {
+                    "selected_attempt": attempt,
+                    "error": f"{type(exc).__name__}: {exc}",
+                    "retry_feedback": retry_feedback,
+                }
+                if raw_response_path is not None:
+                    result_payload["model_response_path"] = str(raw_response_path)
+                write_json(attempt_dir / "result.json", result_payload)
             except Exception as exc:  # noqa: BLE001
                 last_error = exc
                 if builder:
                     previous_builder = builder
                 retry_feedback = self._build_retry_feedback(exc)
                 (attempt_dir / "error.log").write_text(traceback.format_exc(), encoding="utf-8")
-                write_json(
-                    attempt_dir / "result.json",
-                    {
-                        "selected_attempt": attempt,
-                        "error": f"{type(exc).__name__}: {exc}",
-                        "retry_feedback": retry_feedback,
-                    },
-                )
+                result_payload = {
+                    "selected_attempt": attempt,
+                    "error": f"{type(exc).__name__}: {exc}",
+                    "retry_feedback": retry_feedback,
+                }
+                if raw_response_path is not None:
+                    result_payload["model_response_path"] = str(raw_response_path)
+                if builder_path.exists():
+                    result_payload["builder_path"] = str(builder_path)
+                write_json(attempt_dir / "result.json", result_payload)
             if attempt < runtime_cfg.max_attempts and runtime_cfg.sleep_seconds > 0:
                 time.sleep(runtime_cfg.sleep_seconds)
 
@@ -888,4 +909,3 @@ async function generateSlide() {{
             "Fix the JavaScript and return a full fresh `buildSlide(slide, pptx)` function. "
             f"Runtime error: {type(exc).__name__}: {exc}"
         )
-


### PR DESCRIPTION
- detect truncated `buildSlide()` / `generateSlide()` outputs earlier
- preserve raw model responses for failed editable slide attempts
- capture browser runtime and console errors for clearer debugging
- tighten oversized MinerU asset matching and refinement behavior
- improve screenshot-style cutout cropping with placeholder-constrained, subject-centered trimming
- keep graphic/illustration handling separate to avoid damaging non-symmetric assets